### PR TITLE
face sim multiple strategies

### DIFF
--- a/src/pixelbrain/apps/face_similarity/face_similarity_scorer.py
+++ b/src/pixelbrain/apps/face_similarity/face_similarity_scorer.py
@@ -19,37 +19,34 @@ class FaceSimilartyScorer:
         compare_to_dir (str): The directory for the images to compare against.
         source_type (str): The type of source, either 'cloudinary' or 'local'.
         database (Database): An optional database instance for storing results. If not provided, a new one is created.
-        scoring_strategy (str): The strategy to use for scoring the distance between embeddings. Defaults to "nearest".
-        k_nearest (int): k nearest vectors to compare if k average_k_nearest strategy is used
+        scoring_strategies (List[str]): The strategies to use for scoring the distance between embeddings.
+            Options are "nearest", "maximum_distance" or "average_k_nearest". Defaults to ["nearest"].
+        score_field_name_prefix (str): The prefix for the score field names. Defaults to "face_similarity_score". This will be followed by the strategy name.
+        n_closest_compare_to_to_consider (int): The number of closest vectors to compare to. Defaults to 15.
+        k_nearest (int): k nearest vectors to compare if k average_k_nearest strategy is used. Defaults to 5.
     """
 
     def __init__(
         self,
         source_dir: str,
         compare_to_dir: str,
-        source_type: str = 'cloudinary',
-        database: Database = None,
-        scoring_strategy: str = "nearest",
-        score_field_name: str = "face_similarity_score",
-        n_closest_compare_to_to_consider: int = 40,
-        k_nearest: int = 5
+        database: Database,
+        source_type: str = "cloudinary",
+        scoring_strategies: List[str] = ["nearest"],
+        score_field_name_prefix: str = "face_similarity_score",
+        n_closest_compare_to_to_consider: int = 15,
+        k_nearest: int = 5,
     ):
         self._database_created = False
         if not database:
             database = Database()
             self._database_created = True
 
-        if source_type == 'cloudinary':
-            self._tested_dataloader = CloudinaryDataLoader(
-                source_dir, database
-            )
-            self._compare_to_dataloader = CloudinaryDataLoader(
-                compare_to_dir, database
-            )
-        elif source_type == 'local':
-            self._tested_dataloader = DataLoader(
-                source_dir, database, load_images=True
-            )
+        if source_type == "cloudinary":
+            self._tested_dataloader = CloudinaryDataLoader(source_dir, database)
+            self._compare_to_dataloader = CloudinaryDataLoader(compare_to_dir, database)
+        elif source_type == "local":
+            self._tested_dataloader = DataLoader(source_dir, database, load_images=True)
             self._compare_to_dataloader = DataLoader(
                 compare_to_dir, database, load_images=True
             )
@@ -60,31 +57,23 @@ class FaceSimilartyScorer:
         self._database = database
         # generate unique field names so we would not compare to vectors generated from another session
         self._tested_embedding_field_name = f"face_embedding_tested_{uuid4().hex[:16]}"
-        self._compare_to_embedding_field_name = f"face_embedding_compare_to_{uuid4().hex[:16]}"
+        self._compare_to_embedding_field_name = (
+            f"face_embedding_compare_to_{uuid4().hex[:16]}"
+        )
         self._matcher = FaceSimilarityPipeline(
             self._tested_dataloader,
             self._compare_to_dataloader,
             database,
-            scoring_strategy=scoring_strategy,
-            score_field_name=score_field_name,
+            scoring_strategies=scoring_strategies,
+            score_field_name_prefix=score_field_name_prefix,
             n_closest_compare_to_to_consider=n_closest_compare_to_to_consider,
             k_nearest=k_nearest,
             tested_embedding_field_name=self._tested_embedding_field_name,
-            compare_to_embedding_field_name=self._compare_to_embedding_field_name
+            compare_to_embedding_field_name=self._compare_to_embedding_field_name,
         )
-        self._scoring_field_name = score_field_name
+        self._scoring_field_name = score_field_name_prefix
         self._logger = get_logger("CloudinaryFaceSimilartyScorer")
 
     def process(self) -> List[str]:
         """Processes the images to match faces using the configured pipeline."""
         self._matcher.process()
-        results_meta = self._database.find_images_with_value(
-            self._tested_embedding_field_name,
-            value=None,
-            sort_by=self._scoring_field_name,
-            ascending=True,
-        )
-        if self._database_created:
-            self._database.delete_db()
-        
-        return [result['_id'] for result in results_meta]

--- a/src/pixelbrain/pipelines/face_similarity_pipeline.py
+++ b/src/pixelbrain/pipelines/face_similarity_pipeline.py
@@ -11,13 +11,6 @@ from uuid import uuid4
 class FaceSimilarityPipeline(TaggingPipeline):
     """
     A pipeline for matching faces by comparing embeddings generated from two different data loaders.
-
-    Attributes:
-        tested_dataloader (DataLoader): The data loader for the images to be tested.
-        compare_to_dataloader (DataLoader): The data loader for the images to compare against.
-        database (Database): The database instance for storing and retrieving embeddings.
-        scoring_strategy (str): The strategy to use for scoring the distance between embeddings. Defaults to "nearest".
-        k_nearest (int): k nearest vectors to compare if k average_k_nearest strategy is used
     """
 
     def __init__(
@@ -25,8 +18,8 @@ class FaceSimilarityPipeline(TaggingPipeline):
         tested_dataloader: DataLoader,
         compare_to_dataloader: DataLoader,
         database: Database,
-        scoring_strategy: str = "nearest",
-        score_field_name: str = "face_similarity_score",
+        scoring_strategies: List[str] = ["nearest"],
+        score_field_name_prefix: str = "face_similarity_score",
         n_closest_compare_to_to_consider: int = 15,
         k_nearest: int = 5,
         tested_embedding_field_name: str = f"face_embedding_tested_{uuid4().hex[:16]}",
@@ -39,7 +32,13 @@ class FaceSimilarityPipeline(TaggingPipeline):
             tested_dataloader (DataLoader): The data loader for the images to be tested.
             compare_to_dataloader (DataLoader): The data loader for the images to compare against.
             database (Database): The database instance for storing and retrieving embeddings.
-            scoring_strategy (str): The strategy to use for scoring the distance between embeddings. Defaults to "nearest".
+            scoring_strategies (List[str]): The strategies to use for scoring the distance between embeddings.
+                                            Options are "nearest", "maximum_distance" or "average_k_nearest". Defaults to ["nearest"].
+            score_field_name_prefix (str): The prefix for the score field names. Defaults to "face_similarity_score". This will be followed by the strategy name.
+            n_closest_compare_to_to_consider (int): The number of closest vectors to compare if k average_k_nearest strategy is used. Defaults to 15.
+            k_nearest (int): k nearest vectors to compare if k average_k_nearest strategy is used. Defaults to 5.
+            tested_embedding_field_name (str): The name of the field in the database to store the tested embeddings. Defaults to a random UUID.
+            compare_to_embedding_field_name (str): The name of the field in the database to store the compare to embeddings. Defaults to a random UUID.
         """
         super().__init__(None, database)
 
@@ -57,14 +56,17 @@ class FaceSimilarityPipeline(TaggingPipeline):
                 embedding_field_name=self._compare_to_embedding_field_name,
             ),
         ]
-        self._scorer = EmbeddingDistanceScorerModule(
-            database,
-            tested_field=self._tested_embedding_field_name,
-            compare_to_field=self._compare_to_embedding_field_name,
-            strategy=scoring_strategy,
-            score_field_name=score_field_name,
-            k_nearest=k_nearest,
-        )
+        self._scorers = [
+            EmbeddingDistanceScorerModule(
+                database,
+                tested_field=self._tested_embedding_field_name,
+                compare_to_field=self._compare_to_embedding_field_name,
+                strategy=strategy,
+                score_field_name=f"{score_field_name_prefix}_{strategy}",
+                k_nearest=k_nearest,
+            )
+            for strategy in scoring_strategies
+        ]
         self._n_closest_compare_to_to_consider = n_closest_compare_to_to_consider
 
     @overrides
@@ -72,6 +74,7 @@ class FaceSimilarityPipeline(TaggingPipeline):
         """
         Post-processes the embeddings by scoring the images using the configured scoring strategy.
         """
-        self._scorer.score_images(
-            n_closest_vectors=self._n_closest_compare_to_to_consider
-        )
+        for scorer in self._scorers:
+            scorer.score_images(
+                n_closest_vectors=self._n_closest_compare_to_to_consider
+            )

--- a/src/pixelbrain/pipelines/face_similarity_pipeline.py
+++ b/src/pixelbrain/pipelines/face_similarity_pipeline.py
@@ -27,7 +27,7 @@ class FaceSimilarityPipeline(TaggingPipeline):
         database: Database,
         scoring_strategy: str = "nearest",
         score_field_name: str = "face_similarity_score",
-        n_closest_compare_to_to_consider: int = 40,
+        n_closest_compare_to_to_consider: int = 15,
         k_nearest: int = 5,
         tested_embedding_field_name: str = f"face_embedding_tested_{uuid4().hex[:16]}",
         compare_to_embedding_field_name: str = f"face_embedding_compare_to_{uuid4().hex[:16]}",

--- a/src/tests/face_similarity/test_face_similarity_scorer.py
+++ b/src/tests/face_similarity/test_face_similarity_scorer.py
@@ -13,7 +13,7 @@ def test_face_similarity_scorer():
         source_dir=source_dir,
         compare_to_dir=compare_to_dir,
         source_type="local",
-        scoring_strategy="nearest",
+        scoring_strategies="nearest",
     )
     results = scorer.process()
     assert isinstance(
@@ -36,7 +36,7 @@ def test_face_similarity_scorer_with_cloudinary_source():
         source_dir=source_dir,
         compare_to_dir=compare_to_dir,
         source_type="cloudinary",
-        scoring_strategy="nearest",
+        scoring_strategies="nearest",
     )
     results = scorer.process()
     assert isinstance(
@@ -60,7 +60,7 @@ def strategies_experiment():
             source_dir=source_dir,
             compare_to_dir=compare_dir,
             source_type=source_type,
-            scoring_strategy=strategy,
+            scoring_strategies=strategy,
         )
         results = scorer.process()
         return results


### PR DESCRIPTION
- **face-similarity-pipeline: consider only 15 closest vectors by default**
- **face-similarity-pipe: support multiple strategies**
- **face-similarity-scorer: support multiple strategies**
- **tests: fix cloudinery test for face sim scorer**
- **tests: added a test with multiple strategies to face_similarity_scorer**
